### PR TITLE
fixed parse_job parameter and undefiend client variable

### DIFF
--- a/apps/core/management/commands/check_beaker.py
+++ b/apps/core/management/commands/check_beaker.py
@@ -5,22 +5,13 @@
 # Email: pstudeni@redhat.com
 # Date: 24.9.2013
 
-import os
-import re
-import ssl
-import sys
-import time
-import xml.dom.minidom
-import xmlrpclib
 import logging
 from datetime import datetime, timedelta
 from optparse import make_option
 from apps.core.models import CheckProgress, Job
 
 from django.conf import settings
-from django.contrib.auth.models import User
-from django.core.management.base import BaseCommand, CommandError
-from django.template.defaultfilters import slugify
+from django.core.management.base import BaseCommand
 
 from apps.core.utils.beaker import Beaker
 from apps.core.utils.date_helpers import currentDate

--- a/apps/core/utils/beaker.py
+++ b/apps/core/utils/beaker.py
@@ -211,7 +211,7 @@ class Beaker:
                      % jobT.id)
         return None
 
-    def parse_job(self, jobid, running=True, date_created=None):
+    def _getXMLRPCClient(self):
         client = xmlrpclib.Server(self.server_url, verbose=0)
         if self.server_url.startswith("https"):
             # workaround ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED]
@@ -219,7 +219,10 @@ class Beaker:
             if sys.version_info >= (2, 7, 9):
                 client = xmlrpclib.Server(self.server_url, verbose=0,
                                           context=ssl._create_unverified_context())
+        return client
 
+    def parse_job(self, jobid, running=True, date_created=None):
+        client = self._getXMLRPCClient()
         data = client.taskactions.task_info(jobid)
 
         # workaround for test which set label with actial date
@@ -252,6 +255,11 @@ class Beaker:
         if not job.is_running:
             job.is_finished = True
         job.save()
+
+    def listJobs(self, filter={}):
+        """List and filter beaker jobs."""
+        client = self._getXMLRPCClient()
+        return client.jobs.filter(filter)
 
 
 class JobGen:


### PR DESCRIPTION
1. client was removed
https://github.com/SatelliteQE/GreenTea/commit/5c98efb6d34203be3fd3915742607d1fd1ad1e74#diff-ff8fa6cfaa00a9998cb6386d25fa4179L76
but is still used
https://github.com/SatelliteQE/GreenTea/blob/master/apps/core/management/commands/check_beaker.py#L97

2. parse_job: created_date - date_created