### PR TITLE
fix - quotes to username and password for bkr

### DIFF
--- a/apps/core/utils/beaker.py
+++ b/apps/core/utils/beaker.py
@@ -75,8 +75,8 @@ class Beaker:
         """
         auth = ""
         if self.username:
-            auth = "--username=%s --password=%s" % (self.username,
-                                                    self.password)
+            auth = "--username='%s' --password='%s'" % (self.username,
+                                                        self.password)
         command = "bkr %s %s %s --hub=%s" % (command, param, auth, self.hub)
         print command
         logger.debug(command)


### PR DESCRIPTION
fixes errors like this:
```
$ python manage.py pickup
bkr job-submit .../__tmp__.xml --username=name --password=passw<rd --hub=https://beaker...com
/bin/sh: rd: No such file or directory
```