### PR TITLE
Use HVM key_value to filter for virtualization capable systems

### DIFF
--- a/apps/core/utils/beaker.xml
+++ b/apps/core/utils/beaker.xml
@@ -65,24 +65,24 @@
           <distro_method op="=" value="nfs"/>
           <distro_arch op="=" value="{{ arch.name }}"/>
         </and>
-        {% if r.hvm %} <distro_virt op="=" value=""/>{% endif %}
+        {% if r.hvm %}<distro_virt op="=" value=""/>{% endif %}
       </distroRequires>
       <hostRequires>
         <and>
           {% if r.hvm %}<key_value key="HVM" op="=" value="1"/>{% endif %}
-{% if r.hvm %}<cpu>
-	<or>
-		<flag op="=" value="vmx"/>
-		<flag op="=" value="svm"/>
-	</or>
-</cpu>{% endif %}
+          {% if r.hvm %}<cpu>
+            <or>
+              <flag op="=" value="vmx"/>
+              <flag op="=" value="svm"/>
+            </or>
+          </cpu>{% endif %}
           <system>
-		    <and>
+            <and>
               <arch op="=" value="{{ arch.name }}"/>
               {% if r.memory %}<memory op="{{r.memory.split.0|htmlentities}}" value="{{ r.memory.split.1 }}"/>{% endif %}
               {% if r.hvm %}<hypervisor op="=" value=""/>{% endif %}
-			</and>
-		  </system>
+            </and>
+          </system>
           <or>
             {% if r.disk %}<disk><size op="{{r.disk.split.0|htmlentities}}" value="{{ r.disk.split.1 }}" units="GB" /></disk>{% endif %}
             {% comment %} https://bugzilla.redhat.com/show_bug.cgi?id=1187402 s390x is aborted with new xml construction{% endcomment %}

--- a/apps/core/utils/beaker.xml
+++ b/apps/core/utils/beaker.xml
@@ -69,6 +69,7 @@
       </distroRequires>
       <hostRequires>
         <and>
+          {% if r.hvm %}<key_value key="HVM" op="=" value="1"/>{% endif %}
 {% if r.hvm %}<cpu>
 	<or>
 		<flag op="=" value="vmx"/>


### PR DESCRIPTION
From Dan Callaghan explanation:

Unfortunately the key-values are still a bit of a mixed bag. It is true 
that we are (slowly) working towards replacing them, but "HVM" is one 
that doesn't yet have a good replacement.

As you've discovered, checking CPU flags is not sufficient to guarantee 
KVM will work. The most common issue preventing it is virt support being 
disabled in the firmware. I imagine there are some other rarer 
possibilities, like kernel refusing to allow KVM due to CPU errata or 
missing features or something like that.

The inventory scripts set HVM=1 only if the kvm_intel or kvm_amd module 
can be successfully loaded, so it really tells you not just "should this 
system support hardware virtualization" but "*does* this system support 
hardware virtualization". Actually it also checks cpuinfo on ia64 as 
well in case you still care about Xen on RHEL5 :-)

So Dan's suggestion of using `<key_value key="HVM" op="=" value="1"/>` is 
the best approach for now.

BTW if you are afraid of your jobs being broken in future when we get 
rid of key-values, don't be. :-) We will continue to populate the 
existing key-values correctly as long as we still have them in Beaker 
(MEMORY being one exception). And if we do remove key-values entirely 
from Beaker in future we will add a translation layer so that filters 
using `<key_value/>` are aliased to the equivalent replacement.