### PR TITLE
Use the local repository.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.dockerignore
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,12 @@ FROM fedora:22
 
 WORKDIR /data/
 
+RUN mkdir -p /data/GreenTea
+ADD . /data/GreenTea/
+
 # install packages
 RUN dnf install git wget findutils -y \
     && wget https://beaker-project.org/yum/beaker-client-Fedora.repo -O /etc/yum.repos.d/beaker-client-Fedora.repo \
-    && git clone https://github.com/SatelliteQE/GreenTea.git \
     && cat GreenTea/requirement/rpms-*.txt | xargs dnf install -y \
     && chmod 755 /data/ -R
 
@@ -25,8 +27,7 @@ ENV HOME /data/GreenTea
 RUN virtualenv $HOME/env \
     && cd $HOME \
     && . env/bin/activate \
-    && pip install -r $HOME/requirement/requirement.txt \
-    && git reset --hard && git pull
+    && pip install -r $HOME/requirement/requirement.txt
 
 # create default value for running service
 RUN python -c 'import random; print "import os\nfrom basic import *\nDEBUG=True\nSECRET_KEY=\"" + "".join([random.choice("abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)") for i in range(50)]) + "\"" ' > GreenTea/tttt/settings/production.py 


### PR DESCRIPTION
I tried to tweak the setup a bit, so obviously I've created new git branch and working tree. Imagine my surprise when my changes weren't observed at all because the ```Dockerfile``` does ```git clone```.

Please consider this patch which just uses the local checkout.

Not just is that faster (I already have the bits locally), it also makes the resulting image about five MB smaller because the .git history is not stored in the image. And of course, it makes ```docker build``` work with the bits you think it would be using -- the bits where you just made your changes.