### PR TITLE
Use curl which is on Fedora images by default.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM fedora:22
 WORKDIR /data/
 
 # install packages
-RUN dnf install git wget findutils -y \
-    && wget https://beaker-project.org/yum/beaker-client-Fedora.repo -O /etc/yum.repos.d/beaker-client-Fedora.repo \
+RUN dnf install git findutils -y \
+    && curl https://beaker-project.org/yum/beaker-client-Fedora.repo -o /etc/yum.repos.d/beaker-client-Fedora.repo \
     && git clone https://github.com/SatelliteQE/GreenTea.git \
     && cat GreenTea/requirement/rpms-*.txt | xargs dnf install -y \
     && chmod 755 /data/ -R


### PR DESCRIPTION
We save 2.5 MB which is not much but if ```curl``` is there, why not use it.