### PR TITLE
schdule script was replaced by beaker script

### DIFF
--- a/apps/core/management/commands/__init__.py
+++ b/apps/core/management/commands/__init__.py
@@ -1,4 +1,3 @@
 import beaker
 import checkrepo
 import check_beaker
-import schedule


### PR DESCRIPTION
fixed:  File "/mnt/tests/RHN-Satellite/Other/GreenTea/Upgrade/GreenTea/apps/core/management/commands/__init__.py", line 4, in <module>
    import schedule
ImportError: No module named schedule