### PR TITLE
Improved design of Longest running tests report

### DIFF
--- a/apps/core/templatetags/listutil.py
+++ b/apps/core/templatetags/listutil.py
@@ -1,0 +1,68 @@
+"""
+Template tags for working with lists.
+
+You'll use these in templates thusly::
+
+    {% load listutil %}
+    {% for sublist in mylist|parition:"3" %}
+        {% for item in mylist %}
+            do something with {{ item }}
+        {% endfor %}
+    {% endfor %}
+"""
+
+from django import template
+
+register = template.Library()
+
+@register.filter
+def partition(thelist, n):
+    """
+    Break a list into ``n`` pieces. The last list may be larger than the rest if
+    the list doesn't break cleanly. That is::
+
+        >>> l = range(10)
+
+        >>> partition(l, 2)
+        [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]
+
+        >>> partition(l, 3)
+        [[0, 1, 2], [3, 4, 5], [6, 7, 8, 9]]
+
+        >>> partition(l, 4)
+        [[0, 1], [2, 3], [4, 5], [6, 7, 8, 9]]
+
+        >>> partition(l, 5)
+        [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]]
+
+    """
+    try:
+        n = int(n)
+        thelist = list(thelist)
+    except (ValueError, TypeError):
+        return [thelist]
+    p = len(thelist) / n
+    return [thelist[p*i:p*(i+1)] for i in range(n - 1)] + [thelist[p*(i+1):]]
+
+@register.filter
+def partition_horizontal(thelist, n):
+    """
+    Break a list into ``n`` peices, but "horizontally." That is, 
+    ``partition_horizontal(range(10), 3)`` gives::
+    
+        [[1, 2, 3],
+         [4, 5, 6],
+         [7, 8, 9],
+         [10]]
+        
+    Clear as mud?
+    """
+    try:
+        n = int(n)
+        thelist = list(thelist)
+    except (ValueError, TypeError):
+        return [thelist]
+    newlists = [list() for i in range(n)]
+    for i, val in enumerate(thelist):
+        newlists[i%n].append(val)
+    return newlists

--- a/tttt/settings/basic.py
+++ b/tttt/settings/basic.py
@@ -368,3 +368,7 @@ REST_FRAMEWORK = {
 }
 ELASTICSEARCH = ()
 ELASTICSEARCH_MAX_SIZE = 10**6  # 10MB
+
+# Time period for which average run time of tests should be computed, in hours
+LONGEST_RUNNING_PERIOD = 168
+LONGEST_RUNNING_COLUMN_LENGTH = 15

--- a/tttt/templates/report.html
+++ b/tttt/templates/report.html
@@ -1,5 +1,6 @@
 {% extends "basic.html" %}
 {% load gitweb %}
+{% load listutil %}
 
 {% block title %}- Reports{% endblock %}
 
@@ -53,16 +54,32 @@
     </table>
   </div>
 </div>
+<h2>Longest running tests</h2>
 <div class="row">
   <div class="col-md-6">
     <table class="table table-striped">
         <tr>
-            <th>Test</th><th>Average run time</th>
+            <th>Test</th><th>Average run time</th><th>Runs</th>
         </tr>
-        {% for it in testlengths %}
+        {% for it in testlengths|partition:"2"|first %}
           <tr>
             <td>{{ it.test__name }}</td>
-            <td>{{ it.avg_duration }}</td>
+            <td>{{ it.avg_duration|floatformat:2 }}</td>
+            <td>{{ it.runs }}</td>
+          </tr>
+        {% endfor %}
+    </table>
+  </div>
+  <div class="col-md-6">
+    <table class="table table-striped">
+        <tr>
+            <th>Test</th><th>Average run time</th><th>Runs</th>
+        </tr>
+        {% for it in testlengths|partition:"2"|last %}
+          <tr>
+            <td>{{ it.test__name }}</td>
+            <td>{{ it.avg_duration|floatformat:2 }}</td>
+            <td>{{ it.runs }}</td>
           </tr>
         {% endfor %}
     </table>


### PR DESCRIPTION
Filtering by correct date field. Split into two columns, only showing 30 longest tests by default. Also showing number of runs from which the average run time has been computed.