### PR TITLE
Apply role from recipe's group task template to tasks that do not specify their own role.

### DIFF
--- a/apps/core/utils/beaker.py
+++ b/apps/core/utils/beaker.py
@@ -338,6 +338,8 @@ class JobGen:
                 params2 = taskT.get_params()
                 params2.update(params)
                 taskT.parent_params = params2
+                if taskG.role is not None and taskT.role is None:
+                    taskT.role = taskG.role
                 cache_tasks.append(self.__generateTask(taskT))
 
         # other tasks show after groups


### PR DESCRIPTION
Fixes https://github.com/SatelliteQE/GreenTea/issues/110.

Untested, consider it a meta-code.